### PR TITLE
Solve issue that prevents installation on Python 3.4 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 import os
 import re
 
-from distribute_setup import use_setuptools; use_setuptools()
 from setuptools import setup
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,12 @@
 import os
 import re
 
+try:
+    import setuptools
+except ImportError:
+    from distribute_setup import use_setuptools
+    use_setuptools()
+
 from setuptools import setup
 
 


### PR DESCRIPTION
Installation on Python 3.4 always failed without the provided change in `setup.py`
