### PR TITLE
Overloaded redis client support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ HotQueue
 ========
 |PyPI|
 
+(It is a fork where Redis client can be overloaded with already configured client or fakeredis for testing purposes).
+
 HotQueue is a Python library that allows you to use `Redis <http://code.google.com/p/redis/>`_ as a message queue within your Python programs.
 
 The main advantage of this model is that there is no queue server to run, other than Redis. This is particularly ideal if you're already using Redis as a datastore elsewhere. To install it, run::

--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -1,1 +1,2 @@
 redis>=2.0.0
+fakeredis>=0.8.0

--- a/hotqueue.py
+++ b/hotqueue.py
@@ -40,10 +40,13 @@ class HotQueue(object):
         :attr:`host`, :attr:`port`, :attr:`db`
     """
     
-    def __init__(self, name, serializer=pickle, **kwargs):
+    def __init__(self, name, serializer=pickle, overloaded_redis_cli=None, **kwargs):
         self.name = name
         self.serializer = serializer
-        self.__redis = Redis(**kwargs)
+        if overloaded_redis_cli:
+            self.__redis = overloaded_redis_cli
+        else:
+            self.__redis = Redis(**kwargs)
     
     def __len__(self):
         return self.__redis.llen(self.key)

--- a/tests.py
+++ b/tests.py
@@ -15,6 +15,7 @@ except ImportError:
     import pickle
 
 from hotqueue import HotQueue
+import fakeredis
 
 
 class DummySerializer(object):
@@ -32,6 +33,7 @@ class HotQueueTestCase(unittest.TestCase):
     def setUp(self):
         """Create the queue instance before the test."""
         self.queue = HotQueue('testqueue')
+        self.queue_fakeredis = HotQueue('test_queue_fakeredis', overloaded_redis_cli=fakeredis.FakeStrictRedis())
     
     def tearDown(self):
         """Clear the queue after the test."""
@@ -165,6 +167,11 @@ class HotQueueTestCase(unittest.TestCase):
         self.queue.put(msg)
         self.assertEqual(self.queue.get(), "foo")
 
+    def test__hq_should_communicate_over_fakeredis(self):
+        self.queue_fakeredis.put("test content 1")
+        self.queue_fakeredis.put("test content 2")
+        self.assertEqual("test content 1", self.queue_fakeredis.get(block=True, timeout=.001))
+        self.assertEqual("test content 2", self.queue_fakeredis.get(block=True, timeout=.001))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi there, I've added possibility to provide already configured Redis client. This can be useful for unit testing or inter-process communication without the need of a real Redis server. 

I'm not sure why change is master is also considered the scope of this pull request; only overloaded-redis-client-support branch should be pulled. 